### PR TITLE
Fix BlockBlobService constructor for use with Azurite

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,5 +5,6 @@ CONFIG = {
     "port": os.environ.get("hosts_file_port"),
     "hosts_grpc_network": os.environ.get("hosts_file_network"),
     "storage": os.environ.get("hosts_azure_storage"),
-    "storage_key": os.environ.get("hosts_azure_key")
+    "storage_key": os.environ.get("hosts_azure_key"),
+    "blob_storage": os.environ.get("hosts_blob_storage")
 }

--- a/service/utility.py
+++ b/service/utility.py
@@ -6,7 +6,8 @@ from azure.storage.blob import BlockBlobService, PublicAccess
 
 CHUNK_SIZE = 1024 * 1024
 block_blob_service = BlockBlobService(account_name=config.CONFIG["storage"],
-                                      account_key=config.CONFIG["storage_key"])
+                                      account_key=config.CONFIG["storage_key"],
+                                      connection_string="BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;")
 
 
 def download_chunk(file):

--- a/service/utility.py
+++ b/service/utility.py
@@ -5,9 +5,7 @@ import hwsc_file_transaction_svc_pb2
 from azure.storage.blob import BlockBlobService, PublicAccess
 
 CHUNK_SIZE = 1024 * 1024
-block_blob_service = BlockBlobService(account_name=config.CONFIG["storage"],
-                                      account_key=config.CONFIG["storage_key"],
-                                      connection_string="BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;")
+block_blob_service = BlockBlobService(connection_string=config.CONFIG["blob_storage"])
 
 
 def download_chunk(file):


### PR DESCRIPTION
Tried using different combinations of BlockBlobService parameters to no avail. I think `connection_string` must be used. However, I was able to shorten the string significantly while still maintaining functionality with Azurite.