### PR TITLE
Refactor utility.py and implement timestamp validation

### DIFF
--- a/service/file_transaction_service.py
+++ b/service/file_transaction_service.py
@@ -1,7 +1,8 @@
 import grpc
 import hwsc_file_transaction_svc_pb2
 import hwsc_file_transaction_svc_pb2_grpc
-from service import server, utility
+from service import server
+from utility import utility
 
 
 class FileTransactionService(hwsc_file_transaction_svc_pb2_grpc.FileTransactionServiceServicer):

--- a/utility/test_utility.py
+++ b/utility/test_utility.py
@@ -1,5 +1,5 @@
 import pytest
-from service import utility
+from utility import utility
 
 
 @pytest.mark.parametrize("input, expected_output",

--- a/utility/utility.py
+++ b/utility/utility.py
@@ -3,6 +3,7 @@ import re
 import config
 import hwsc_file_transaction_svc_pb2
 from azure.storage.blob import BlockBlobService, PublicAccess
+import time
 
 CHUNK_SIZE = 1024 * 1024
 block_blob_service = BlockBlobService(connection_string=config.CONFIG["blob_storage"])
@@ -138,3 +139,10 @@ def get_property(request_iterator):
 
         d["stream"] = stream
     return d
+
+
+def is_expired(timestamp):
+    """Determine if a given timestamp has expired"""
+    if timestamp <= 0 or time.time() >= timestamp:
+        return True
+    return False


### PR DESCRIPTION
From my tests, `time.time()` in Python is equivalent to `time.Now().UTC().Unix()` and `time.Now().Unix()` in Go.

Refactoring is tested; `file_transaction_svc.py` is still able to communicate with `utility.py`.